### PR TITLE
Upgrade Refiner Android SDK version to 1.3.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         minSdkVersion 21
         targetSdk 34
         versionCode 1
-        versionName "1.3.5-rn"
+        versionName "1.3.6"
     }
     lintOptions {
         abortOnError false
@@ -52,5 +52,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.refiner:refiner:1.3.5-rn'
+    implementation 'io.refiner:refiner:1.3.6'
 }


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner Android SDK to version 1.3.6

# How to test it

1. Run the app
2. See the survey shows up successfully

# Acceptance criteria

* Example app runs successfully