### PR TITLE
Upgrade native SDK versions to 1.3.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         minSdkVersion 21
         targetSdk 34
         versionCode 1
-        versionName "1.3.6"
+        versionName "1.3.10"
     }
     lintOptions {
         abortOnError false
@@ -52,5 +52,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.refiner:refiner:1.3.6'
+    implementation 'io.refiner:refiner:1.3.10'
 }

--- a/ios/RNRefiner.podspec
+++ b/ios/RNRefiner.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNRefiner"
-  s.version      = "1.3.4"
+  s.version      = "1.3.10"
   s.summary      = "RNRefiner"
   s.description  = <<-DESC
                   RNRefiner


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner Android and iOS SDKs to version 1.3.10

# How to test it

1. Replace node_module content with updated RN sdk
2. Run projects

# Acceptance criteria

*  See the version 1.3.10 on initializations