### PR TITLE
chore: update refiner sdk, add types, clean few things

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         minSdkVersion 21
         targetSdk 34
         versionCode 1
-        versionName "1.3.10"
+        versionName "1.3.11"
     }
     lintOptions {
         abortOnError false
@@ -52,5 +52,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.refiner:refiner:1.3.10'
+    implementation 'io.refiner:refiner:1.3.11'
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+import { NativeModule } from "react-native";
+
+export interface RefinerSDKInterface extends NativeModule {
+  addToResponse: (response: Record<string, unknown> | null) => void;
+  identifyUser: (
+    userId: string,
+    userTraits: Record<string, unknown>,
+    locale: string | null,
+    identityVerification: string | null
+  ) => Promise<void>;
+  initialize: (projectId: string, debugMode: boolean) => void;
+  resetUser: () => void;
+  setProject: (projectId: string | null) => void;
+  trackEvent: (eventName: string) => void;
+}
+
+declare module "react-native" {
+  interface NativeModulesStatic {
+    RNRefiner: RefinerSDKInterface;
+  }
+}

--- a/ios/RNRefiner.podspec
+++ b/ios/RNRefiner.podspec
@@ -1,15 +1,11 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNRefiner"
-  s.version      = "1.3.10"
-  s.summary      = "RNRefiner"
-  s.description  = <<-DESC
-                  RNRefiner
-                   DESC
-  s.homepage     = ""
+  s.version      = "1.3.11"
+  s.summary      = "Official React Native wrapper for the Refiner.io Mobile SDK"
+  s.homepage     = "https://github.com/refiner-io/mobile-sdk-react-native"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.author       = { "Refiner" => "contact@refiner.io" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/RNRefiner.git", :tag => "master" }
   s.source_files  = "RNRefiner/**/*.{h,m}"
@@ -18,8 +14,6 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   s.dependency "RefinerSDK"
-  #s.dependency "others"
-
 end
 
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refiner-react-native",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refiner-react-native",
-      "version": "1.3.10",
+      "version": "1.3.11",
       "license": "MIT",
       "peerDependencies": {
         "react-native": "^0.73.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "refiner-react-native",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Official React Native wrapper for the Refiner.io Mobile SDK",
   "homepage": "https://github.com/refiner-io/mobile-sdk-react-native",
   "repository": {
@@ -11,11 +11,18 @@
     "refiner.io",
     "survey"
   ],
-  "bugs": "https://github.com/refiner-io/mobile-sdk-react-native/issues",
-  "author": "Refiner <contact@refiner.io> (https://refiner.io)",
+  "bugs": {
+    "url": "https://github.com/refiner-io/mobile-sdk-react-native/issues"
+  },
+  "author": {
+    "name": "Refiner",
+    "email": "contact@refiner.io",
+    "url": "https://refiner.io"
+  },
   "license": "MIT",
   "private": false,
   "peerDependencies": {
     "react-native": "^0.73.2"
-  }
+  },
+  "types": "index.d.ts"
 }

--- a/refiner-react-native.podspec
+++ b/refiner-react-native.podspec
@@ -6,13 +6,9 @@ Pod::Spec.new do |s|
   s.name         = "refiner-react-native"
   s.version      = package["version"]
   s.summary      = package["description"]
-  s.description  = <<-DESC
-                  Refiner SDK React Native
-                   DESC
   s.homepage     = "https://github.com/refiner-io/mobile-sdk-react-native"
   s.license      = "MIT"
-  # s.license    = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.authors      = { "Refiner" => "" }
+  s.author       = { package["author"]["name"] => package["author"]["email"] }
   s.platforms    = { :ios => "10.0" }
   s.source       = { :git => "https://github.com/refiner-io/mobile-sdk-react-native.git", :tag => "#{s.version}" }
 
@@ -21,7 +17,5 @@ Pod::Spec.new do |s|
 
   s.dependency "React"
   s.dependency "RefinerSDK"
-  # ...
-  # s.dependency "..."
 end
 


### PR DESCRIPTION
I was originally just going to add the typescript types but noticed that there's a new version of Refiner so updated that as well and cleaned a few parts

# What it does

1. This pull request; 

- Upgrades Refiner Android and iOS SDKs to version 1.3.11
- Adds the typescript types

# How to test it

1. Replace node_module content with updated RN SDK
2. Run projects

# Acceptance criteria

-  See the version 1.3.11 on initializations