### PR TITLE
Upgrade Android SDK to 1.3.12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         minSdkVersion 21
         targetSdk 34
         versionCode 1
-        versionName "1.3.11"
+        versionName "1.3.12"
     }
     lintOptions {
         abortOnError false
@@ -52,5 +52,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.refiner:refiner:1.3.11'
+    implementation 'io.refiner:refiner:1.3.12'
 }


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner Android SDK to version 1.3.12

# How to test it

1. Replace node_module content with updated RN SDK
2. Run example project

# Acceptance criteria

*  See the version 1.3.12 on initializations