### PR TITLE
Upgrade native SDK versions to 1.4.0 and add startSession method

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         minSdkVersion 21
         targetSdk 34
         versionCode 1
-        versionName "1.3.12"
+        versionName "1.4.0"
     }
     lintOptions {
         abortOnError false
@@ -52,5 +52,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.refiner:refiner:1.3.12'
+    implementation 'io.refiner:refiner:1.4.0'
 }

--- a/android/src/main/java/io/refiner/rn/RNRefinerModule.java
+++ b/android/src/main/java/io/refiner/rn/RNRefinerModule.java
@@ -111,6 +111,11 @@ public class RNRefinerModule extends ReactContextBaseJavaModule {
         Refiner.INSTANCE.addToResponse(contextualDataMap);
     }
 
+    @ReactMethod
+    public void startSession() {
+        Refiner.INSTANCE.startSession();
+    }
+
     @Deprecated
     @ReactMethod
     public void attachToResponse(ReadableMap contextualData) {

--- a/ios/RNRefiner.m
+++ b/ios/RNRefiner.m
@@ -93,6 +93,11 @@ RCT_EXPORT_METHOD(addToResponse:(NSDictionary *)contextualData)
     [[Refiner instance] addToResponseWithData: contextualData];
 }
 
+RCT_EXPORT_METHOD(startSession)
+{
+    [[Refiner instance] startSession];
+}
+
 - (void) registerCallbacks {
     [[Refiner instance] setOnBeforeShow:^(NSString * formId, id formConfig) {
         [self emitEventInternal:kRefinerOnBeforeShow andBody: @{kRefinerFormId: formId,

--- a/ios/RNRefiner.podspec
+++ b/ios/RNRefiner.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNRefiner"
-  s.version      = "1.3.11"
+  s.version      = "1.4.0"
   s.summary      = "Official React Native wrapper for the Refiner.io Mobile SDK"
   s.homepage     = "https://github.com/refiner-io/mobile-sdk-react-native"
   s.license      = "MIT"


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner iOS and Android SDK versions to 1.4.0
2. Adds startSession method

# How to test it

1. Implement startSession method
4. Run the app
5. Open app and see the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully and sends startSession request