### PR TITLE
Upgrade native SDK versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,5 +52,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.refiner:refiner:1.5.4'
+    implementation 'io.refiner:refiner:1.5.5'
 }

--- a/ios/RNRefiner.podspec
+++ b/ios/RNRefiner.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNRefiner"
-  s.version      = "1.6.0"
+  s.version      = "1.6.1"
   s.summary      = "Official React Native wrapper for the Refiner.io Mobile SDK"
   s.homepage     = "https://github.com/refiner-io/mobile-sdk-react-native"
   s.license      = "MIT"
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
 
   s.dependency "React"
-  s.dependency "RefinerSDK"
+  s.dependency "RefinerSDK", "~> 1.5.5"
 end
 
   

--- a/refiner-react-native.podspec
+++ b/refiner-react-native.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "RefinerSDK"
+  s.dependency "RefinerSDK", "~> 1.5.5"
 end
 


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner iOS to 1.5.5 and Android SDK to 1.5.5

# How to test it

1. Run the app
2. Open app and see the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully