### PR TITLE
Upgrade Native SDK versions and add onError callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,12 @@ A popular use-case for callback functions is to redirect a user to a new screen 
     console.log(event.formData);
   });   
 ```     
+
+`onError` gets called when an error occurred.
+
+```javascript
+  RNRefinerEventEmitter.addListener('onError', (event) => {
+    console.log('onError');
+    console.log(event.meesage);
+  });   
+```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ android {
         minSdkVersion 21
         targetSdk 35
         versionCode 1
-        versionName "1.6.0"
+        versionName "1.6.4"
     }
     lintOptions {
         abortOnError false
@@ -52,5 +52,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.refiner:refiner:1.5.5'
+    implementation 'io.refiner:refiner:1.5.6'
 }

--- a/android/src/main/java/io/refiner/rn/RNRefinerModule.java
+++ b/android/src/main/java/io/refiner/rn/RNRefinerModule.java
@@ -194,6 +194,13 @@ public class RNRefinerModule extends ReactContextBaseJavaModule {
             sendEvent("onNavigation", params);
             return null;
         });
+
+        Refiner.INSTANCE.onError((message) -> {
+            WritableMap params = Arguments.createMap();
+            params.putString("message", message.toString());
+            sendEvent("onError", params);
+            return null;
+        });
     }
 
     private void sendEvent(String eventName, Object params) {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -111,6 +111,10 @@ function App(): JSX.Element {
     console.log(event.formData);
   });
 
+    RNRefinerEventEmitter.addListener('onError', (event) => {
+    console.log('onError');
+    console.log(event.message);
+  });
 
   const isDarkMode = useColorScheme() === 'dark';
 

--- a/ios/RNRefiner.m
+++ b/ios/RNRefiner.m
@@ -10,12 +10,14 @@ static NSString *const kRefinerOnShow           = @"onShow";
 static NSString *const kRefinerOnClose          = @"onClose";
 static NSString *const kRefinerOnDismiss        = @"onDismiss";
 static NSString *const kRefinerOnComplete       = @"onComplete";
+static NSString *const kRefinerOnError          = @"onError";
 #pragma mark - Constant Name
 static NSString *const kRefinerFormId           = @"formId";
 static NSString *const kRefinerFormConfig       = @"formConfig";
 static NSString *const kRefinerFormElement      = @"formElement";
 static NSString *const kRefinerProgress         = @"progress";
 static NSString *const kRefinerFormData         = @"formData";
+static NSString *const kRefinerMessage          = @"message";
 
 @implementation RNRefiner
 
@@ -33,7 +35,8 @@ RCT_EXPORT_MODULE()
         kRefinerOnShow,
         kRefinerOnClose,
         kRefinerOnDismiss,
-        kRefinerOnComplete
+        kRefinerOnComplete,
+        kRefinerOnError
     ];
 }
 
@@ -130,6 +133,10 @@ RCT_EXPORT_METHOD(startSession)
     [[Refiner instance] setOnComplete:^(NSString * formId, id formData) {
         [self emitEventInternal:kRefinerOnComplete andBody:  @{kRefinerFormId: formId,
                                                                kRefinerFormData: formData}];
+    }];
+    
+    [[Refiner instance] setOnError:^(NSString * message) {
+        [self emitEventInternal:kRefinerOnError andBody: @{kRefinerMessage: message}];
     }];
 }
 

--- a/ios/RNRefiner.podspec
+++ b/ios/RNRefiner.podspec
@@ -1,8 +1,8 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNRefiner"
-  s.version      = "1.6.1"
-  s.summary      = "Official React Native wrapper for the Refiner.io Mobile SDK"
+  s.version      = "1.6.4"
+  s.summary      = "Official React Native wrapper for the Refiner Mobile SDK"
   s.homepage     = "https://github.com/refiner-io/mobile-sdk-react-native"
   s.license      = "MIT"
   s.author       = { "Refiner" => "contact@refiner.io" }
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
 
   s.dependency "React"
-  s.dependency "RefinerSDK", "~> 1.5.5"
+  s.dependency "RefinerSDK", "~> 1.5.6"
 end
 
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refiner-react-native",
-  "version": "1.6.1",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refiner-react-native",
-      "version": "1.6.1",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "@react-native-community/cli-platform-android": "^16.0.2"

--- a/refiner-react-native.podspec
+++ b/refiner-react-native.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "RefinerSDK", "~> 1.5.5"
+  s.dependency "RefinerSDK", "~> 1.5.6"
 end
 


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner iOS SDK to 1.5.6 and Android SDK to 1.5.6

# How to test it

1. Run the app
2. Open app and see the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully