### PR TITLE
Upgrade native iOS SDK version

### DIFF
--- a/ios/RNRefiner.podspec
+++ b/ios/RNRefiner.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNRefiner"
-  s.version      = "1.7.0"
+  s.version      = "1.7.1"
   s.summary      = "Official React Native wrapper for the Refiner Mobile SDK"
   s.homepage     = "https://github.com/refiner-io/mobile-sdk-react-native"
   s.license      = "MIT"
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   }
 
   s.dependency "React"
-  s.dependency "RefinerSDK", "~> 1.5.8"
+  s.dependency "RefinerSDK", "~> 1.5.9"
 end
 
   

--- a/refiner-react-native.podspec
+++ b/refiner-react-native.podspec
@@ -71,6 +71,6 @@ Pod::Spec.new do |s|
   end
 
   # RefinerSDK dependency
-  s.dependency "RefinerSDK", "~> 1.5.8"
+  s.dependency "RefinerSDK", "~> 1.5.9"
 end
 


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner iOS to 1.5.9

# How to test it

1. Run the app
2. Open app and see the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully