### PR TITLE
Upgrade native SDK versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ android {
         minSdkVersion getExtOrIntegerDefault("minSdkVersion") ?: 21
         targetSdkVersion getExtOrIntegerDefault("targetSdkVersion") ?: 35
         versionCode 1
-        versionName "1.7.0"
+        versionName "1.7.2"
 
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     }
@@ -124,7 +124,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-android:+"
-    implementation 'io.refiner:refiner:1.5.7'
+    implementation 'io.refiner:refiner:1.5.8'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0"
 }

--- a/refiner-react-native.podspec
+++ b/refiner-react-native.podspec
@@ -71,6 +71,6 @@ Pod::Spec.new do |s|
   end
 
   # RefinerSDK dependency
-  s.dependency "RefinerSDK", "~> 1.5.9"
+  s.dependency "RefinerSDK", "~> 1.5.10"
 end
 


### PR DESCRIPTION
# What it does

1. This pull request upgrades Refiner iOS to 1.5.10 and Android SDK to 1.5.8

# How to test it

1. Run the app
2. Open app and see the survey shows up successfully

# Acceptance criteria

* No issues appears during project build
* Example app runs successfully