### PR TITLE
chore: update android native SDK to 1.7.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,7 +110,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-android:+"
-    implementation 'io.refiner:refiner:1.7.2'
+    implementation 'io.refiner:refiner:1.7.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,7 +110,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-android:+"
-    implementation 'io.refiner:refiner:1.7.3'
+    implementation 'io.refiner:refiner:1.7.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1"
 }


### PR DESCRIPTION
# What it does

Updates the android native SDK dependency to version `1.7.4`.

# How to test it

1. Build and run the example app
2. Verify the SDK initializes correctly with the new native version

# Acceptance criteria

* Native SDK dependency points to `1.7.4`
* No breaking changes in bridge/wrapper code (review if new native APIs require updates)

# Link to ticket

Automated — triggered by a new release in `mobile-sdk-internal`.